### PR TITLE
PG GroupByCube Syntax Extension

### DIFF
--- a/lib/arel/nodes/unary.rb
+++ b/lib/arel/nodes/unary.rb
@@ -23,6 +23,10 @@ module Arel
     %w{
       Bin
       Group
+      Cube
+      RollUp
+      GroupingSet
+      GroupingElement
       Having
       Limit
       Not

--- a/lib/arel/visitors/depth_first.rb
+++ b/lib/arel/visitors/depth_first.rb
@@ -17,6 +17,10 @@ module Arel
         visit o.expr
       end
       alias :visit_Arel_Nodes_Group             :unary
+      alias :visit_Arel_Nodes_Cube              :unary
+      alias :visit_Arel_Nodes_RollUp            :unary
+      alias :visit_Arel_Nodes_GroupingSet       :unary
+      alias :visit_Arel_Nodes_GroupingElement   :unary
       alias :visit_Arel_Nodes_Grouping          :unary
       alias :visit_Arel_Nodes_Having            :unary
       alias :visit_Arel_Nodes_Limit             :unary

--- a/lib/arel/visitors/dot.rb
+++ b/lib/arel/visitors/dot.rb
@@ -69,6 +69,10 @@ module Arel
         visit_edge o, "expr"
       end
       alias :visit_Arel_Nodes_Group             :unary
+      alias :visit_Arel_Nodes_Cube              :unary
+      alias :visit_Arel_Nodes_RollUp            :unary
+      alias :visit_Arel_Nodes_GroupingSet       :unary
+      alias :visit_Arel_Nodes_GroupingElement   :unary
       alias :visit_Arel_Nodes_Grouping          :unary
       alias :visit_Arel_Nodes_Having            :unary
       alias :visit_Arel_Nodes_Limit             :unary

--- a/lib/arel/visitors/postgresql.rb
+++ b/lib/arel/visitors/postgresql.rb
@@ -1,7 +1,43 @@
 module Arel
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
+      CUBE = 'CUBE'
+      ROLLUP = 'ROLLUP'
+      GROUPING_SET = 'GROUPING SET'
+
       private
+
+      def visit_Arel_Nodes_GroupingElement o, collector
+        collector << "( "
+        visit(o.expr, collector) << " )"
+      end
+
+      def visit_Arel_Nodes_Cube o, collector
+        collector << CUBE
+        grouping_array_or_grouping_element(o, collector)
+      end
+
+      def visit_Arel_Nodes_RollUp o, collector
+        collector << ROLLUP
+        grouping_array_or_grouping_element(o, collector)
+      end
+
+      def visit_Arel_Nodes_GroupingSet o, collector
+        collector << GROUPING_SET
+        grouping_array_or_grouping_element(o, collector)
+      end
+
+      # Utilized by GroupingSet, Cube & RollUp visitors to
+      # handle grouping aggregation semantics
+      def grouping_array_or_grouping_element o, collector
+        if o.expr.is_a?(Array)
+          collector << "( "
+          visit(o.expr, collector)
+          collector << " )"
+        else
+          visit(o.expr, collector)
+        end
+      end
 
       def visit_Arel_Nodes_Matches o, collector
         infix_value o, collector, ' ILIKE '

--- a/test/visitors/test_postgres.rb
+++ b/test/visitors/test_postgres.rb
@@ -127,6 +127,84 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::Cube" do
+        it "should know how to visit with array arguments" do
+          node = Arel::Nodes::Cube.new([@table[:name], @table[:bool]])
+          compile(node).must_be_like %{
+            CUBE( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to visit with CubeDimension Argument" do
+          dimensions = Arel::Nodes::GroupingElement.new([@table[:name], @table[:bool]])
+          node = Arel::Nodes::Cube.new(dimensions)
+          compile(node).must_be_like %{
+            CUBE( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to generate paranthesis when supplied with many Dimensions" do
+          dim1 = Arel::Nodes::GroupingElement.new(@table[:name])
+          dim2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
+          node = Arel::Nodes::Cube.new([dim1, dim2])
+          compile(node).must_be_like %{
+            CUBE( ( "users"."name" ), ( "users"."bool", "users"."created_at" ) )
+          }
+        end
+      end
+
+      describe "Nodes::GroupingSet" do
+        it "should know how to visit with array arguments" do
+          node = Arel::Nodes::GroupingSet.new([@table[:name], @table[:bool]])
+          compile(node).must_be_like %{
+            GROUPING SET( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to visit with CubeDimension Argument" do
+          group = Arel::Nodes::GroupingElement.new([@table[:name], @table[:bool]])
+          node = Arel::Nodes::GroupingSet.new(group)
+          compile(node).must_be_like %{
+            GROUPING SET( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to generate paranthesis when supplied with many Dimensions" do
+          group1 = Arel::Nodes::GroupingElement.new(@table[:name])
+          group2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
+          node = Arel::Nodes::GroupingSet.new([group1, group2])
+          compile(node).must_be_like %{
+            GROUPING SET( ( "users"."name" ), ( "users"."bool", "users"."created_at" ) )
+          }
+        end
+      end
+
+      describe "Nodes::RollUp" do
+        it "should know how to visit with array arguments" do
+          node = Arel::Nodes::RollUp.new([@table[:name], @table[:bool]])
+          compile(node).must_be_like %{
+            ROLLUP( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to visit with CubeDimension Argument" do
+          group = Arel::Nodes::GroupingElement.new([@table[:name], @table[:bool]])
+          node = Arel::Nodes::RollUp.new(group)
+          compile(node).must_be_like %{
+            ROLLUP( "users"."name", "users"."bool" )
+          }
+        end
+
+        it "should know how to generate paranthesis when supplied with many Dimensions" do
+          group1 = Arel::Nodes::GroupingElement.new(@table[:name])
+          group2 = Arel::Nodes::GroupingElement.new([@table[:bool], @table[:created_at]])
+          node = Arel::Nodes::RollUp.new([group1, group2])
+          compile(node).must_be_like %{
+            ROLLUP( ( "users"."name" ), ( "users"."bool", "users"."created_at" ) )
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
adds support for the new `GROUP BY CUBE (dim1, dim2, ..)`
